### PR TITLE
Retiring our Rancher fork

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/rancher_manager.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_manager.go
@@ -207,8 +207,8 @@ func (m *RancherManager) DeleteNode(nodePoolId string, node *v1.Node) error {
 		return fmt.Errorf("node %s not found", node.Name)
 	}
 
-	klog.Infof("Marking node %s (%s) for deletion", rancherNode.ID, rancherNode.NodeName)
-	err = m.nodes.ActionPleaseKillMe(rancherNode)
+	klog.Infof("Scaling down node %s (%s)", rancherNode.ID, rancherNode.NodeName)
+	err = m.nodes.ActionScaledown(rancherNode)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -22,8 +22,8 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/json-iterator/go v1.1.10
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b
-	github.com/rancher/rancher/pkg/client v0.0.0-20210826004905-903c574c8351
+	github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
+	github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
@@ -33,7 +33,7 @@ require (
 	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8
-	k8s.io/apimachinery v0.18.8
+	k8s.io/apimachinery v0.21.0
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.18.8
 	k8s.io/cloud-provider v0.0.0
@@ -442,8 +442,8 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
 
 replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
 
-replace github.com/rancher/norman => github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b
+replace github.com/rancher/norman => github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
 
-replace github.com/rancher/rancher/pkg/client => github.com/PlayKids/rancher/pkg/client v0.0.0-20210826004905-903c574c8351
+replace github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c
 
 replace k8s.io/kubernetes => /tmp/ca-update-vendor.NGE2/kubernetes

--- a/cluster-autoscaler/go.mod-extra
+++ b/cluster-autoscaler/go.mod-extra
@@ -4,10 +4,6 @@ go 1.12
 require (
   github.com/digitalocean/godo v1.27.0
   github.com/rancher/go-rancher v0.1.0
-  github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b
-  github.com/rancher/rancher/pkg/client v0.0.0-20210826004905-903c574c8351
-)
-
-replace (
-  github.com/rancher/rancher/pkg/client => github.com/PlayKids/rancher/pkg/client v0.0.0-20210826004905-903c574c8351
+  github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
+  github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c
 )

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -44,8 +44,6 @@ github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990 h1:1xpVY4dSUS
 github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990/go.mod h1:ay/0dTb7NsG8QMDfsRfLHgZo/6xAJShLe1+ePPflihk=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 h1:lsxEuwrXEAokXB9qhlbKWPpo3KMLZQ5WB5WLQRW1uq0=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
-github.com/PlayKids/rancher/pkg/client v0.0.0-20210826004905-903c574c8351 h1:oV3d2G/WCSIv8xk/UpYo54GJcwpkz2vQWwk7DHtogLg=
-github.com/PlayKids/rancher/pkg/client v0.0.0-20210826004905-903c574c8351/go.mod h1:iUy4JIYYA0BBQ7nFxueLJYDCYg7Hhoo+VY5t9HQXmlc=
 github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -409,8 +407,10 @@ github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4do
 github.com/quobyte/api v0.1.8 h1:+sOX1gIlC/OaLipqVZWrHgly9Kh9Qo8OygeS0mWAg30=
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
-github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b h1:4SV/mEqaGmwvAV5XIO+hRqacZR1KyW6sTqzFNIlyTAY=
-github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
+github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133 h1:X1Tn2q3iDekvqajJCbY2QYkEUJ51rJC9BuxS3os6nX4=
+github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
+github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c h1:UI4rTxVT+sDcTiujSjjnhEjo3ejXnAcB3YkJVIhDI8M=
+github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c/go.mod h1:UKAFuyRUIHtnss0+u3/21KZzsD4F/1IaHCBazsHKaww=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106 h1:ed0NTDvIwulez4zVvBZ1U7mFe2PBxtHvJ9bn2l9bcZ8=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/cluster-autoscaler/vendor/github.com/rancher/norman/types/reflection.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/norman/types/reflection.go
@@ -393,6 +393,8 @@ func applyTag(structField *reflect.StructField, field *Field) error {
 			field.ValidChars = value
 		case "invalidChars":
 			field.InvalidChars = value
+		case "pointer":
+			field.Pointer = true
 		default:
 			return fmt.Errorf("invalid tag %s on field %s", key, structField.Name)
 		}

--- a/cluster-autoscaler/vendor/github.com/rancher/norman/types/types.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/norman/types/types.go
@@ -150,6 +150,7 @@ type Field struct {
 	Description  string      `json:"description,omitempty"`
 	CodeName     string      `json:"-"`
 	DynamicField bool        `json:"dynamicField,omitempty"`
+	Pointer      bool        `json:"pointer,omitempty"`
 }
 
 type Action struct {

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aes_configuration.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aes_configuration.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	AESConfigurationType      = "aesConfiguration"
+	AESConfigurationFieldKeys = "keys"
+)
+
+type AESConfiguration struct {
+	Keys []Key `json:"keys,omitempty" yaml:"keys,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aks_cluster_config_spec.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aks_cluster_config_spec.go
@@ -1,0 +1,66 @@
+package client
+
+const (
+	AKSClusterConfigSpecType                             = "aksClusterConfigSpec"
+	AKSClusterConfigSpecFieldAuthBaseURL                 = "authBaseUrl"
+	AKSClusterConfigSpecFieldAuthorizedIPRanges          = "authorizedIpRanges"
+	AKSClusterConfigSpecFieldAzureCredentialSecret       = "azureCredentialSecret"
+	AKSClusterConfigSpecFieldBaseURL                     = "baseUrl"
+	AKSClusterConfigSpecFieldClusterName                 = "clusterName"
+	AKSClusterConfigSpecFieldDNSPrefix                   = "dnsPrefix"
+	AKSClusterConfigSpecFieldHTTPApplicationRouting      = "httpApplicationRouting"
+	AKSClusterConfigSpecFieldImported                    = "imported"
+	AKSClusterConfigSpecFieldKubernetesVersion           = "kubernetesVersion"
+	AKSClusterConfigSpecFieldLinuxAdminUsername          = "linuxAdminUsername"
+	AKSClusterConfigSpecFieldLinuxSSHPublicKey           = "sshPublicKey"
+	AKSClusterConfigSpecFieldLoadBalancerSKU             = "loadBalancerSku"
+	AKSClusterConfigSpecFieldLogAnalyticsWorkspaceGroup  = "logAnalyticsWorkspaceGroup"
+	AKSClusterConfigSpecFieldLogAnalyticsWorkspaceName   = "logAnalyticsWorkspaceName"
+	AKSClusterConfigSpecFieldMonitoring                  = "monitoring"
+	AKSClusterConfigSpecFieldNetworkDNSServiceIP         = "dnsServiceIp"
+	AKSClusterConfigSpecFieldNetworkDockerBridgeCIDR     = "dockerBridgeCidr"
+	AKSClusterConfigSpecFieldNetworkPlugin               = "networkPlugin"
+	AKSClusterConfigSpecFieldNetworkPodCIDR              = "podCidr"
+	AKSClusterConfigSpecFieldNetworkPolicy               = "networkPolicy"
+	AKSClusterConfigSpecFieldNetworkServiceCIDR          = "serviceCidr"
+	AKSClusterConfigSpecFieldNodePools                   = "nodePools"
+	AKSClusterConfigSpecFieldPrivateCluster              = "privateCluster"
+	AKSClusterConfigSpecFieldResourceGroup               = "resourceGroup"
+	AKSClusterConfigSpecFieldResourceLocation            = "resourceLocation"
+	AKSClusterConfigSpecFieldSubnet                      = "subnet"
+	AKSClusterConfigSpecFieldTags                        = "tags"
+	AKSClusterConfigSpecFieldVirtualNetwork              = "virtualNetwork"
+	AKSClusterConfigSpecFieldVirtualNetworkResourceGroup = "virtualNetworkResourceGroup"
+)
+
+type AKSClusterConfigSpec struct {
+	AuthBaseURL                 *string            `json:"authBaseUrl,omitempty" yaml:"authBaseUrl,omitempty"`
+	AuthorizedIPRanges          *[]string          `json:"authorizedIpRanges,omitempty" yaml:"authorizedIpRanges,omitempty"`
+	AzureCredentialSecret       string             `json:"azureCredentialSecret,omitempty" yaml:"azureCredentialSecret,omitempty"`
+	BaseURL                     *string            `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty"`
+	ClusterName                 string             `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	DNSPrefix                   *string            `json:"dnsPrefix,omitempty" yaml:"dnsPrefix,omitempty"`
+	HTTPApplicationRouting      *bool              `json:"httpApplicationRouting,omitempty" yaml:"httpApplicationRouting,omitempty"`
+	Imported                    bool               `json:"imported,omitempty" yaml:"imported,omitempty"`
+	KubernetesVersion           *string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+	LinuxAdminUsername          *string            `json:"linuxAdminUsername,omitempty" yaml:"linuxAdminUsername,omitempty"`
+	LinuxSSHPublicKey           *string            `json:"sshPublicKey,omitempty" yaml:"sshPublicKey,omitempty"`
+	LoadBalancerSKU             *string            `json:"loadBalancerSku,omitempty" yaml:"loadBalancerSku,omitempty"`
+	LogAnalyticsWorkspaceGroup  *string            `json:"logAnalyticsWorkspaceGroup,omitempty" yaml:"logAnalyticsWorkspaceGroup,omitempty"`
+	LogAnalyticsWorkspaceName   *string            `json:"logAnalyticsWorkspaceName,omitempty" yaml:"logAnalyticsWorkspaceName,omitempty"`
+	Monitoring                  *bool              `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`
+	NetworkDNSServiceIP         *string            `json:"dnsServiceIp,omitempty" yaml:"dnsServiceIp,omitempty"`
+	NetworkDockerBridgeCIDR     *string            `json:"dockerBridgeCidr,omitempty" yaml:"dockerBridgeCidr,omitempty"`
+	NetworkPlugin               *string            `json:"networkPlugin,omitempty" yaml:"networkPlugin,omitempty"`
+	NetworkPodCIDR              *string            `json:"podCidr,omitempty" yaml:"podCidr,omitempty"`
+	NetworkPolicy               *string            `json:"networkPolicy,omitempty" yaml:"networkPolicy,omitempty"`
+	NetworkServiceCIDR          *string            `json:"serviceCidr,omitempty" yaml:"serviceCidr,omitempty"`
+	NodePools                   *[]AKSNodePool     `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
+	PrivateCluster              *bool              `json:"privateCluster,omitempty" yaml:"privateCluster,omitempty"`
+	ResourceGroup               string             `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
+	ResourceLocation            string             `json:"resourceLocation,omitempty" yaml:"resourceLocation,omitempty"`
+	Subnet                      *string            `json:"subnet,omitempty" yaml:"subnet,omitempty"`
+	Tags                        *map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	VirtualNetwork              *string            `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
+	VirtualNetworkResourceGroup *string            `json:"virtualNetworkResourceGroup,omitempty" yaml:"virtualNetworkResourceGroup,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aks_node_pool.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aks_node_pool.go
@@ -1,0 +1,34 @@
+package client
+
+const (
+	AKSNodePoolType                     = "aksNodePool"
+	AKSNodePoolFieldAvailabilityZones   = "availabilityZones"
+	AKSNodePoolFieldCount               = "count"
+	AKSNodePoolFieldEnableAutoScaling   = "enableAutoScaling"
+	AKSNodePoolFieldMaxCount            = "maxCount"
+	AKSNodePoolFieldMaxPods             = "maxPods"
+	AKSNodePoolFieldMinCount            = "minCount"
+	AKSNodePoolFieldMode                = "mode"
+	AKSNodePoolFieldName                = "name"
+	AKSNodePoolFieldOrchestratorVersion = "orchestratorVersion"
+	AKSNodePoolFieldOsDiskSizeGB        = "osDiskSizeGB"
+	AKSNodePoolFieldOsDiskType          = "osDiskType"
+	AKSNodePoolFieldOsType              = "osType"
+	AKSNodePoolFieldVMSize              = "vmSize"
+)
+
+type AKSNodePool struct {
+	AvailabilityZones   *[]string `json:"availabilityZones,omitempty" yaml:"availabilityZones,omitempty"`
+	Count               *int64    `json:"count,omitempty" yaml:"count,omitempty"`
+	EnableAutoScaling   *bool     `json:"enableAutoScaling,omitempty" yaml:"enableAutoScaling,omitempty"`
+	MaxCount            *int64    `json:"maxCount,omitempty" yaml:"maxCount,omitempty"`
+	MaxPods             *int64    `json:"maxPods,omitempty" yaml:"maxPods,omitempty"`
+	MinCount            *int64    `json:"minCount,omitempty" yaml:"minCount,omitempty"`
+	Mode                string    `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Name                *string   `json:"name,omitempty" yaml:"name,omitempty"`
+	OrchestratorVersion *string   `json:"orchestratorVersion,omitempty" yaml:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int64    `json:"osDiskSizeGB,omitempty" yaml:"osDiskSizeGB,omitempty"`
+	OsDiskType          string    `json:"osDiskType,omitempty" yaml:"osDiskType,omitempty"`
+	OsType              string    `json:"osType,omitempty" yaml:"osType,omitempty"`
+	VMSize              string    `json:"vmSize,omitempty" yaml:"vmSize,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aks_status.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_aks_status.go
@@ -1,0 +1,14 @@
+package client
+
+const (
+	AKSStatusType                       = "aksStatus"
+	AKSStatusFieldPrivateRequiresTunnel = "privateRequiresTunnel"
+	AKSStatusFieldRBACEnabled           = "rbacEnabled"
+	AKSStatusFieldUpstreamSpec          = "upstreamSpec"
+)
+
+type AKSStatus struct {
+	PrivateRequiresTunnel *bool                 `json:"privateRequiresTunnel,omitempty" yaml:"privateRequiresTunnel,omitempty"`
+	RBACEnabled           *bool                 `json:"rbacEnabled,omitempty" yaml:"rbacEnabled,omitempty"`
+	UpstreamSpec          *AKSClusterConfigSpec `json:"upstreamSpec,omitempty" yaml:"upstreamSpec,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_answer.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_answer.go
@@ -1,14 +1,16 @@
 package client
 
 const (
-	AnswerType           = "answer"
-	AnswerFieldClusterID = "clusterId"
-	AnswerFieldProjectID = "projectId"
-	AnswerFieldValues    = "values"
+	AnswerType                 = "answer"
+	AnswerFieldClusterID       = "clusterId"
+	AnswerFieldProjectID       = "projectId"
+	AnswerFieldValues          = "values"
+	AnswerFieldValuesSetString = "valuesSetString"
 )
 
 type Answer struct {
-	ClusterID string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
-	ProjectID string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
-	Values    map[string]string `json:"values,omitempty" yaml:"values,omitempty"`
+	ClusterID       string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
+	ProjectID       string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	Values          map[string]string `json:"values,omitempty" yaml:"values,omitempty"`
+	ValuesSetString map[string]string `json:"valuesSetString,omitempty" yaml:"valuesSetString,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_bastion_host.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_bastion_host.go
@@ -1,24 +1,26 @@
 package client
 
 const (
-	BastionHostType              = "bastionHost"
-	BastionHostFieldAddress      = "address"
-	BastionHostFieldPort         = "port"
-	BastionHostFieldSSHAgentAuth = "sshAgentAuth"
-	BastionHostFieldSSHCert      = "sshCert"
-	BastionHostFieldSSHCertPath  = "sshCertPath"
-	BastionHostFieldSSHKey       = "sshKey"
-	BastionHostFieldSSHKeyPath   = "sshKeyPath"
-	BastionHostFieldUser         = "user"
+	BastionHostType                    = "bastionHost"
+	BastionHostFieldAddress            = "address"
+	BastionHostFieldIgnoreProxyEnvVars = "ignoreProxyEnvVars"
+	BastionHostFieldPort               = "port"
+	BastionHostFieldSSHAgentAuth       = "sshAgentAuth"
+	BastionHostFieldSSHCert            = "sshCert"
+	BastionHostFieldSSHCertPath        = "sshCertPath"
+	BastionHostFieldSSHKey             = "sshKey"
+	BastionHostFieldSSHKeyPath         = "sshKeyPath"
+	BastionHostFieldUser               = "user"
 )
 
 type BastionHost struct {
-	Address      string `json:"address,omitempty" yaml:"address,omitempty"`
-	Port         string `json:"port,omitempty" yaml:"port,omitempty"`
-	SSHAgentAuth bool   `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
-	SSHCert      string `json:"sshCert,omitempty" yaml:"sshCert,omitempty"`
-	SSHCertPath  string `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
-	SSHKey       string `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
-	SSHKeyPath   string `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
-	User         string `json:"user,omitempty" yaml:"user,omitempty"`
+	Address            string `json:"address,omitempty" yaml:"address,omitempty"`
+	IgnoreProxyEnvVars bool   `json:"ignoreProxyEnvVars,omitempty" yaml:"ignoreProxyEnvVars,omitempty"`
+	Port               string `json:"port,omitempty" yaml:"port,omitempty"`
+	SSHAgentAuth       bool   `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
+	SSHCert            string `json:"sshCert,omitempty" yaml:"sshCert,omitempty"`
+	SSHCertPath        string `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
+	SSHKey             string `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
+	SSHKeyPath         string `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
+	User               string `json:"user,omitempty" yaml:"user,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cloud_credential.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cloud_credential.go
@@ -5,29 +5,31 @@ import (
 )
 
 const (
-	CloudCredentialType                 = "cloudCredential"
-	CloudCredentialFieldAnnotations     = "annotations"
-	CloudCredentialFieldCreated         = "created"
-	CloudCredentialFieldCreatorID       = "creatorId"
-	CloudCredentialFieldDescription     = "description"
-	CloudCredentialFieldLabels          = "labels"
-	CloudCredentialFieldName            = "name"
-	CloudCredentialFieldOwnerReferences = "ownerReferences"
-	CloudCredentialFieldRemoved         = "removed"
-	CloudCredentialFieldUUID            = "uuid"
+	CloudCredentialType                    = "cloudCredential"
+	CloudCredentialFieldAnnotations        = "annotations"
+	CloudCredentialFieldCreated            = "created"
+	CloudCredentialFieldCreatorID          = "creatorId"
+	CloudCredentialFieldDescription        = "description"
+	CloudCredentialFieldLabels             = "labels"
+	CloudCredentialFieldName               = "name"
+	CloudCredentialFieldOwnerReferences    = "ownerReferences"
+	CloudCredentialFieldRemoved            = "removed"
+	CloudCredentialFieldS3CredentialConfig = "s3credentialConfig"
+	CloudCredentialFieldUUID               = "uuid"
 )
 
 type CloudCredential struct {
 	types.Resource
-	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID       string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Description     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
-	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	UUID            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations        map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Created            string              `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID          string              `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Description        string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Labels             map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name               string              `json:"name,omitempty" yaml:"name,omitempty"`
+	OwnerReferences    []OwnerReference    `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed            string              `json:"removed,omitempty" yaml:"removed,omitempty"`
+	S3CredentialConfig *S3CredentialConfig `json:"s3credentialConfig,omitempty" yaml:"s3credentialConfig,omitempty"`
+	UUID               string              `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 
 type CloudCredentialCollection struct {

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cloud_credential_spec.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cloud_credential_spec.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	CloudCredentialSpecType             = "cloudCredentialSpec"
-	CloudCredentialSpecFieldDescription = "description"
-	CloudCredentialSpecFieldDisplayName = "displayName"
+	CloudCredentialSpecType                    = "cloudCredentialSpec"
+	CloudCredentialSpecFieldDescription        = "description"
+	CloudCredentialSpecFieldDisplayName        = "displayName"
+	CloudCredentialSpecFieldS3CredentialConfig = "s3credentialConfig"
 )
 
 type CloudCredentialSpec struct {
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description        string              `json:"description,omitempty" yaml:"description,omitempty"`
+	DisplayName        string              `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	S3CredentialConfig *S3CredentialConfig `json:"s3credentialConfig,omitempty" yaml:"s3credentialConfig,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster.go
@@ -6,6 +6,8 @@ import (
 
 const (
 	ClusterType                                      = "cluster"
+	ClusterFieldAKSConfig                            = "aksConfig"
+	ClusterFieldAKSStatus                            = "aksStatus"
 	ClusterFieldAPIEndpoint                          = "apiEndpoint"
 	ClusterFieldAgentEnvVars                         = "agentEnvVars"
 	ClusterFieldAgentFeatures                        = "agentFeatures"
@@ -76,6 +78,8 @@ const (
 
 type Cluster struct {
 	types.Resource
+	AKSConfig                            *AKSClusterConfigSpec          `json:"aksConfig,omitempty" yaml:"aksConfig,omitempty"`
+	AKSStatus                            *AKSStatus                     `json:"aksStatus,omitempty" yaml:"aksStatus,omitempty"`
 	APIEndpoint                          string                         `json:"apiEndpoint,omitempty" yaml:"apiEndpoint,omitempty"`
 	AgentEnvVars                         []EnvVar                       `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
 	AgentFeatures                        map[string]bool                `json:"agentFeatures,omitempty" yaml:"agentFeatures,omitempty"`

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_registration_token.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_registration_token.go
@@ -5,49 +5,53 @@ import (
 )
 
 const (
-	ClusterRegistrationTokenType                      = "clusterRegistrationToken"
-	ClusterRegistrationTokenFieldAnnotations          = "annotations"
-	ClusterRegistrationTokenFieldClusterID            = "clusterId"
-	ClusterRegistrationTokenFieldCommand              = "command"
-	ClusterRegistrationTokenFieldCreated              = "created"
-	ClusterRegistrationTokenFieldCreatorID            = "creatorId"
-	ClusterRegistrationTokenFieldInsecureCommand      = "insecureCommand"
-	ClusterRegistrationTokenFieldLabels               = "labels"
-	ClusterRegistrationTokenFieldManifestURL          = "manifestUrl"
-	ClusterRegistrationTokenFieldName                 = "name"
-	ClusterRegistrationTokenFieldNamespaceId          = "namespaceId"
-	ClusterRegistrationTokenFieldNodeCommand          = "nodeCommand"
-	ClusterRegistrationTokenFieldOwnerReferences      = "ownerReferences"
-	ClusterRegistrationTokenFieldRemoved              = "removed"
-	ClusterRegistrationTokenFieldState                = "state"
-	ClusterRegistrationTokenFieldToken                = "token"
-	ClusterRegistrationTokenFieldTransitioning        = "transitioning"
-	ClusterRegistrationTokenFieldTransitioningMessage = "transitioningMessage"
-	ClusterRegistrationTokenFieldUUID                 = "uuid"
-	ClusterRegistrationTokenFieldWindowsNodeCommand   = "windowsNodeCommand"
+	ClusterRegistrationTokenType                            = "clusterRegistrationToken"
+	ClusterRegistrationTokenFieldAnnotations                = "annotations"
+	ClusterRegistrationTokenFieldClusterID                  = "clusterId"
+	ClusterRegistrationTokenFieldCommand                    = "command"
+	ClusterRegistrationTokenFieldCreated                    = "created"
+	ClusterRegistrationTokenFieldCreatorID                  = "creatorId"
+	ClusterRegistrationTokenFieldInsecureCommand            = "insecureCommand"
+	ClusterRegistrationTokenFieldInsecureNodeCommand        = "insecureNodeCommand"
+	ClusterRegistrationTokenFieldInsecureWindowsNodeCommand = "insecureWindowsNodeCommand"
+	ClusterRegistrationTokenFieldLabels                     = "labels"
+	ClusterRegistrationTokenFieldManifestURL                = "manifestUrl"
+	ClusterRegistrationTokenFieldName                       = "name"
+	ClusterRegistrationTokenFieldNamespaceId                = "namespaceId"
+	ClusterRegistrationTokenFieldNodeCommand                = "nodeCommand"
+	ClusterRegistrationTokenFieldOwnerReferences            = "ownerReferences"
+	ClusterRegistrationTokenFieldRemoved                    = "removed"
+	ClusterRegistrationTokenFieldState                      = "state"
+	ClusterRegistrationTokenFieldToken                      = "token"
+	ClusterRegistrationTokenFieldTransitioning              = "transitioning"
+	ClusterRegistrationTokenFieldTransitioningMessage       = "transitioningMessage"
+	ClusterRegistrationTokenFieldUUID                       = "uuid"
+	ClusterRegistrationTokenFieldWindowsNodeCommand         = "windowsNodeCommand"
 )
 
 type ClusterRegistrationToken struct {
 	types.Resource
-	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	ClusterID            string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
-	Command              string            `json:"command,omitempty" yaml:"command,omitempty"`
-	Created              string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID            string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	InsecureCommand      string            `json:"insecureCommand,omitempty" yaml:"insecureCommand,omitempty"`
-	Labels               map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	ManifestURL          string            `json:"manifestUrl,omitempty" yaml:"manifestUrl,omitempty"`
-	Name                 string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NamespaceId          string            `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
-	NodeCommand          string            `json:"nodeCommand,omitempty" yaml:"nodeCommand,omitempty"`
-	OwnerReferences      []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed              string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	State                string            `json:"state,omitempty" yaml:"state,omitempty"`
-	Token                string            `json:"token,omitempty" yaml:"token,omitempty"`
-	Transitioning        string            `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
-	TransitioningMessage string            `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
-	UUID                 string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	WindowsNodeCommand   string            `json:"windowsNodeCommand,omitempty" yaml:"windowsNodeCommand,omitempty"`
+	Annotations                map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	ClusterID                  string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
+	Command                    string            `json:"command,omitempty" yaml:"command,omitempty"`
+	Created                    string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID                  string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	InsecureCommand            string            `json:"insecureCommand,omitempty" yaml:"insecureCommand,omitempty"`
+	InsecureNodeCommand        string            `json:"insecureNodeCommand,omitempty" yaml:"insecureNodeCommand,omitempty"`
+	InsecureWindowsNodeCommand string            `json:"insecureWindowsNodeCommand,omitempty" yaml:"insecureWindowsNodeCommand,omitempty"`
+	Labels                     map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	ManifestURL                string            `json:"manifestUrl,omitempty" yaml:"manifestUrl,omitempty"`
+	Name                       string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NamespaceId                string            `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
+	NodeCommand                string            `json:"nodeCommand,omitempty" yaml:"nodeCommand,omitempty"`
+	OwnerReferences            []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed                    string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	State                      string            `json:"state,omitempty" yaml:"state,omitempty"`
+	Token                      string            `json:"token,omitempty" yaml:"token,omitempty"`
+	Transitioning              string            `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+	TransitioningMessage       string            `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
+	UUID                       string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	WindowsNodeCommand         string            `json:"windowsNodeCommand,omitempty" yaml:"windowsNodeCommand,omitempty"`
 }
 
 type ClusterRegistrationTokenCollection struct {

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_registration_token_status.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_registration_token_status.go
@@ -1,20 +1,24 @@
 package client
 
 const (
-	ClusterRegistrationTokenStatusType                    = "clusterRegistrationTokenStatus"
-	ClusterRegistrationTokenStatusFieldCommand            = "command"
-	ClusterRegistrationTokenStatusFieldInsecureCommand    = "insecureCommand"
-	ClusterRegistrationTokenStatusFieldManifestURL        = "manifestUrl"
-	ClusterRegistrationTokenStatusFieldNodeCommand        = "nodeCommand"
-	ClusterRegistrationTokenStatusFieldToken              = "token"
-	ClusterRegistrationTokenStatusFieldWindowsNodeCommand = "windowsNodeCommand"
+	ClusterRegistrationTokenStatusType                            = "clusterRegistrationTokenStatus"
+	ClusterRegistrationTokenStatusFieldCommand                    = "command"
+	ClusterRegistrationTokenStatusFieldInsecureCommand            = "insecureCommand"
+	ClusterRegistrationTokenStatusFieldInsecureNodeCommand        = "insecureNodeCommand"
+	ClusterRegistrationTokenStatusFieldInsecureWindowsNodeCommand = "insecureWindowsNodeCommand"
+	ClusterRegistrationTokenStatusFieldManifestURL                = "manifestUrl"
+	ClusterRegistrationTokenStatusFieldNodeCommand                = "nodeCommand"
+	ClusterRegistrationTokenStatusFieldToken                      = "token"
+	ClusterRegistrationTokenStatusFieldWindowsNodeCommand         = "windowsNodeCommand"
 )
 
 type ClusterRegistrationTokenStatus struct {
-	Command            string `json:"command,omitempty" yaml:"command,omitempty"`
-	InsecureCommand    string `json:"insecureCommand,omitempty" yaml:"insecureCommand,omitempty"`
-	ManifestURL        string `json:"manifestUrl,omitempty" yaml:"manifestUrl,omitempty"`
-	NodeCommand        string `json:"nodeCommand,omitempty" yaml:"nodeCommand,omitempty"`
-	Token              string `json:"token,omitempty" yaml:"token,omitempty"`
-	WindowsNodeCommand string `json:"windowsNodeCommand,omitempty" yaml:"windowsNodeCommand,omitempty"`
+	Command                    string `json:"command,omitempty" yaml:"command,omitempty"`
+	InsecureCommand            string `json:"insecureCommand,omitempty" yaml:"insecureCommand,omitempty"`
+	InsecureNodeCommand        string `json:"insecureNodeCommand,omitempty" yaml:"insecureNodeCommand,omitempty"`
+	InsecureWindowsNodeCommand string `json:"insecureWindowsNodeCommand,omitempty" yaml:"insecureWindowsNodeCommand,omitempty"`
+	ManifestURL                string `json:"manifestUrl,omitempty" yaml:"manifestUrl,omitempty"`
+	NodeCommand                string `json:"nodeCommand,omitempty" yaml:"nodeCommand,omitempty"`
+	Token                      string `json:"token,omitempty" yaml:"token,omitempty"`
+	WindowsNodeCommand         string `json:"windowsNodeCommand,omitempty" yaml:"windowsNodeCommand,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_spec.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_spec.go
@@ -2,6 +2,7 @@ package client
 
 const (
 	ClusterSpecType                                     = "clusterSpec"
+	ClusterSpecFieldAKSConfig                           = "aksConfig"
 	ClusterSpecFieldAgentEnvVars                        = "agentEnvVars"
 	ClusterSpecFieldAgentImageOverride                  = "agentImageOverride"
 	ClusterSpecFieldAmazonElasticContainerServiceConfig = "amazonElasticContainerServiceConfig"
@@ -36,6 +37,7 @@ const (
 )
 
 type ClusterSpec struct {
+	AKSConfig                           *AKSClusterConfigSpec          `json:"aksConfig,omitempty" yaml:"aksConfig,omitempty"`
 	AgentEnvVars                        []EnvVar                       `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
 	AgentImageOverride                  string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	AmazonElasticContainerServiceConfig map[string]interface{}         `json:"amazonElasticContainerServiceConfig,omitempty" yaml:"amazonElasticContainerServiceConfig,omitempty"`

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_status.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_cluster_status.go
@@ -2,6 +2,7 @@ package client
 
 const (
 	ClusterStatusType                                      = "clusterStatus"
+	ClusterStatusFieldAKSStatus                            = "aksStatus"
 	ClusterStatusFieldAPIEndpoint                          = "apiEndpoint"
 	ClusterStatusFieldAgentFeatures                        = "agentFeatures"
 	ClusterStatusFieldAgentImage                           = "agentImage"
@@ -34,6 +35,7 @@ const (
 )
 
 type ClusterStatus struct {
+	AKSStatus                            *AKSStatus                  `json:"aksStatus,omitempty" yaml:"aksStatus,omitempty"`
 	APIEndpoint                          string                      `json:"apiEndpoint,omitempty" yaml:"apiEndpoint,omitempty"`
 	AgentFeatures                        map[string]bool             `json:"agentFeatures,omitempty" yaml:"agentFeatures,omitempty"`
 	AgentImage                           string                      `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_ecr_credential_plugin.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_ecr_credential_plugin.go
@@ -1,0 +1,14 @@
+package client
+
+const (
+	ECRCredentialPluginType                    = "ecrCredentialPlugin"
+	ECRCredentialPluginFieldAwsAccessKeyID     = "awsAccessKeyId"
+	ECRCredentialPluginFieldAwsSecretAccessKey = "awsSecretAccessKey"
+	ECRCredentialPluginFieldAwsSessionToken    = "awsAccessToken"
+)
+
+type ECRCredentialPlugin struct {
+	AwsAccessKeyID     string `json:"awsAccessKeyId,omitempty" yaml:"awsAccessKeyId,omitempty"`
+	AwsSecretAccessKey string `json:"awsSecretAccessKey,omitempty" yaml:"awsSecretAccessKey,omitempty"`
+	AwsSessionToken    string `json:"awsAccessToken,omitempty" yaml:"awsAccessToken,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_eks_cluster_config_spec.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_eks_cluster_config_spec.go
@@ -21,20 +21,20 @@ const (
 )
 
 type EKSClusterConfigSpec struct {
-	AmazonCredentialSecret string            `json:"amazonCredentialSecret,omitempty" yaml:"amazonCredentialSecret,omitempty"`
-	DisplayName            string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	Imported               bool              `json:"imported,omitempty" yaml:"imported,omitempty"`
-	KmsKey                 string            `json:"kmsKey,omitempty" yaml:"kmsKey,omitempty"`
-	KubernetesVersion      string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
-	LoggingTypes           []string          `json:"loggingTypes,omitempty" yaml:"loggingTypes,omitempty"`
-	NodeGroups             []NodeGroup       `json:"nodeGroups,omitempty" yaml:"nodeGroups,omitempty"`
-	PrivateAccess          *bool             `json:"privateAccess,omitempty" yaml:"privateAccess,omitempty"`
-	PublicAccess           *bool             `json:"publicAccess,omitempty" yaml:"publicAccess,omitempty"`
-	PublicAccessSources    []string          `json:"publicAccessSources,omitempty" yaml:"publicAccessSources,omitempty"`
-	Region                 string            `json:"region,omitempty" yaml:"region,omitempty"`
-	SecretsEncryption      *bool             `json:"secretsEncryption,omitempty" yaml:"secretsEncryption,omitempty"`
-	SecurityGroups         []string          `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
-	ServiceRole            string            `json:"serviceRole,omitempty" yaml:"serviceRole,omitempty"`
-	Subnets                []string          `json:"subnets,omitempty" yaml:"subnets,omitempty"`
-	Tags                   map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	AmazonCredentialSecret string             `json:"amazonCredentialSecret,omitempty" yaml:"amazonCredentialSecret,omitempty"`
+	DisplayName            string             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Imported               bool               `json:"imported,omitempty" yaml:"imported,omitempty"`
+	KmsKey                 *string            `json:"kmsKey,omitempty" yaml:"kmsKey,omitempty"`
+	KubernetesVersion      *string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+	LoggingTypes           *[]string          `json:"loggingTypes,omitempty" yaml:"loggingTypes,omitempty"`
+	NodeGroups             *[]NodeGroup       `json:"nodeGroups,omitempty" yaml:"nodeGroups,omitempty"`
+	PrivateAccess          *bool              `json:"privateAccess,omitempty" yaml:"privateAccess,omitempty"`
+	PublicAccess           *bool              `json:"publicAccess,omitempty" yaml:"publicAccess,omitempty"`
+	PublicAccessSources    *[]string          `json:"publicAccessSources,omitempty" yaml:"publicAccessSources,omitempty"`
+	Region                 string             `json:"region,omitempty" yaml:"region,omitempty"`
+	SecretsEncryption      *bool              `json:"secretsEncryption,omitempty" yaml:"secretsEncryption,omitempty"`
+	SecurityGroups         *[]string          `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
+	ServiceRole            *string            `json:"serviceRole,omitempty" yaml:"serviceRole,omitempty"`
+	Subnets                *[]string          `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+	Tags                   *map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_encryption_configuration.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_encryption_configuration.go
@@ -1,0 +1,14 @@
+package client
+
+const (
+	EncryptionConfigurationType            = "encryptionConfiguration"
+	EncryptionConfigurationFieldAPIVersion = "apiVersion"
+	EncryptionConfigurationFieldKind       = "kind"
+	EncryptionConfigurationFieldResources  = "resources"
+)
+
+type EncryptionConfiguration struct {
+	APIVersion string                  `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind       string                  `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Resources  []ResourceConfiguration `json:"resources,omitempty" yaml:"resources,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_ephemeral_volume_source.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_ephemeral_volume_source.go
@@ -2,11 +2,9 @@ package client
 
 const (
 	EphemeralVolumeSourceType                     = "ephemeralVolumeSource"
-	EphemeralVolumeSourceFieldReadOnly            = "readOnly"
 	EphemeralVolumeSourceFieldVolumeClaimTemplate = "volumeClaimTemplate"
 )
 
 type EphemeralVolumeSource struct {
-	ReadOnly            bool                           `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	VolumeClaimTemplate *PersistentVolumeClaimTemplate `json:"volumeClaimTemplate,omitempty" yaml:"volumeClaimTemplate,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_feature_status.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_feature_status.go
@@ -5,10 +5,12 @@ const (
 	FeatureStatusFieldDefault     = "default"
 	FeatureStatusFieldDescription = "description"
 	FeatureStatusFieldDynamic     = "dynamic"
+	FeatureStatusFieldLockedValue = "lockedValue"
 )
 
 type FeatureStatus struct {
 	Default     bool   `json:"default,omitempty" yaml:"default,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	Dynamic     bool   `json:"dynamic,omitempty" yaml:"dynamic,omitempty"`
+	LockedValue *bool  `json:"lockedValue,omitempty" yaml:"lockedValue,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_gke_cluster_config_spec.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_gke_cluster_config_spec.go
@@ -29,26 +29,26 @@ const (
 
 type GKEClusterConfigSpec struct {
 	ClusterAddons                  *GKEClusterAddons                  `json:"clusterAddons,omitempty" yaml:"clusterAddons,omitempty"`
-	ClusterIpv4CidrBlock           string                             `json:"clusterIpv4Cidr,omitempty" yaml:"clusterIpv4Cidr,omitempty"`
+	ClusterIpv4CidrBlock           *string                            `json:"clusterIpv4Cidr,omitempty" yaml:"clusterIpv4Cidr,omitempty"`
 	ClusterName                    string                             `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 	Description                    string                             `json:"description,omitempty" yaml:"description,omitempty"`
 	EnableKubernetesAlpha          *bool                              `json:"enableKubernetesAlpha,omitempty" yaml:"enableKubernetesAlpha,omitempty"`
 	GoogleCredentialSecret         string                             `json:"googleCredentialSecret,omitempty" yaml:"googleCredentialSecret,omitempty"`
 	IPAllocationPolicy             *GKEIPAllocationPolicy             `json:"ipAllocationPolicy,omitempty" yaml:"ipAllocationPolicy,omitempty"`
 	Imported                       bool                               `json:"imported,omitempty" yaml:"imported,omitempty"`
-	KubernetesVersion              string                             `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
-	Labels                         map[string]string                  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Locations                      []string                           `json:"locations,omitempty" yaml:"locations,omitempty"`
-	LoggingService                 string                             `json:"loggingService,omitempty" yaml:"loggingService,omitempty"`
-	MaintenanceWindow              string                             `json:"maintenanceWindow,omitempty" yaml:"maintenanceWindow,omitempty"`
+	KubernetesVersion              *string                            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+	Labels                         *map[string]string                 `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Locations                      *[]string                          `json:"locations,omitempty" yaml:"locations,omitempty"`
+	LoggingService                 *string                            `json:"loggingService,omitempty" yaml:"loggingService,omitempty"`
+	MaintenanceWindow              *string                            `json:"maintenanceWindow,omitempty" yaml:"maintenanceWindow,omitempty"`
 	MasterAuthorizedNetworksConfig *GKEMasterAuthorizedNetworksConfig `json:"masterAuthorizedNetworks,omitempty" yaml:"masterAuthorizedNetworks,omitempty"`
-	MonitoringService              string                             `json:"monitoringService,omitempty" yaml:"monitoringService,omitempty"`
-	Network                        string                             `json:"network,omitempty" yaml:"network,omitempty"`
+	MonitoringService              *string                            `json:"monitoringService,omitempty" yaml:"monitoringService,omitempty"`
+	Network                        *string                            `json:"network,omitempty" yaml:"network,omitempty"`
 	NetworkPolicyEnabled           *bool                              `json:"networkPolicyEnabled,omitempty" yaml:"networkPolicyEnabled,omitempty"`
 	NodePools                      []GKENodePoolConfig                `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
 	PrivateClusterConfig           *GKEPrivateClusterConfig           `json:"privateClusterConfig,omitempty" yaml:"privateClusterConfig,omitempty"`
 	ProjectID                      string                             `json:"projectID,omitempty" yaml:"projectID,omitempty"`
 	Region                         string                             `json:"region,omitempty" yaml:"region,omitempty"`
-	Subnetwork                     string                             `json:"subnetwork,omitempty" yaml:"subnetwork,omitempty"`
+	Subnetwork                     *string                            `json:"subnetwork,omitempty" yaml:"subnetwork,omitempty"`
 	Zone                           string                             `json:"zone,omitempty" yaml:"zone,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_gke_node_config.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_gke_node_config.go
@@ -10,6 +10,7 @@ const (
 	GKENodeConfigFieldMachineType   = "machineType"
 	GKENodeConfigFieldOauthScopes   = "oauthScopes"
 	GKENodeConfigFieldPreemptible   = "preemptible"
+	GKENodeConfigFieldTags          = "tags"
 	GKENodeConfigFieldTaints        = "taints"
 )
 
@@ -22,5 +23,6 @@ type GKENodeConfig struct {
 	MachineType   string               `json:"machineType,omitempty" yaml:"machineType,omitempty"`
 	OauthScopes   []string             `json:"oauthScopes,omitempty" yaml:"oauthScopes,omitempty"`
 	Preemptible   bool                 `json:"preemptible,omitempty" yaml:"preemptible,omitempty"`
+	Tags          []string             `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Taints        []GKENodeTaintConfig `json:"taints,omitempty" yaml:"taints,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_gke_node_pool_config.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_gke_node_pool_config.go
@@ -17,6 +17,6 @@ type GKENodePoolConfig struct {
 	InitialNodeCount  *int64                  `json:"initialNodeCount,omitempty" yaml:"initialNodeCount,omitempty"`
 	Management        *GKENodePoolManagement  `json:"management,omitempty" yaml:"management,omitempty"`
 	MaxPodsConstraint *int64                  `json:"maxPodsConstraint,omitempty" yaml:"maxPodsConstraint,omitempty"`
-	Name              string                  `json:"name,omitempty" yaml:"name,omitempty"`
-	Version           string                  `json:"version,omitempty" yaml:"version,omitempty"`
+	Name              *string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	Version           *string                 `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_identity_configuration.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_identity_configuration.go
@@ -1,0 +1,8 @@
+package client
+
+const (
+	IdentityConfigurationType = "identityConfiguration"
+)
+
+type IdentityConfiguration struct {
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
@@ -1,0 +1,50 @@
+package client
+
+const (
+	KeyCloakOIDCConfigType                     = "keyCloakOIDCConfig"
+	KeyCloakOIDCConfigFieldAccessMode          = "accessMode"
+	KeyCloakOIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
+	KeyCloakOIDCConfigFieldAnnotations         = "annotations"
+	KeyCloakOIDCConfigFieldAuthEndpoint        = "authEndpoint"
+	KeyCloakOIDCConfigFieldCertificate         = "certificate"
+	KeyCloakOIDCConfigFieldClientID            = "clientId"
+	KeyCloakOIDCConfigFieldClientSecret        = "clientSecret"
+	KeyCloakOIDCConfigFieldCreated             = "created"
+	KeyCloakOIDCConfigFieldCreatorID           = "creatorId"
+	KeyCloakOIDCConfigFieldEnabled             = "enabled"
+	KeyCloakOIDCConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
+	KeyCloakOIDCConfigFieldIssuer              = "issuer"
+	KeyCloakOIDCConfigFieldLabels              = "labels"
+	KeyCloakOIDCConfigFieldName                = "name"
+	KeyCloakOIDCConfigFieldOwnerReferences     = "ownerReferences"
+	KeyCloakOIDCConfigFieldPrivateKey          = "privateKey"
+	KeyCloakOIDCConfigFieldRancherURL          = "rancherUrl"
+	KeyCloakOIDCConfigFieldRemoved             = "removed"
+	KeyCloakOIDCConfigFieldScopes              = "scope"
+	KeyCloakOIDCConfigFieldType                = "type"
+	KeyCloakOIDCConfigFieldUUID                = "uuid"
+)
+
+type KeyCloakOIDCConfig struct {
+	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Certificate         string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret        string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
+	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
+	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PrivateKey          string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
+	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Scopes              string            `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_kms_configuration.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_kms_configuration.go
@@ -2,15 +2,15 @@ package client
 
 const (
 	KMSConfigurationType           = "kmsConfiguration"
-	KMSConfigurationFieldCacheSize = "cacheSize"
+	KMSConfigurationFieldCacheSize = "cachesize"
 	KMSConfigurationFieldEndpoint  = "endpoint"
 	KMSConfigurationFieldName      = "name"
 	KMSConfigurationFieldTimeout   = "timeout"
 )
 
 type KMSConfiguration struct {
-	CacheSize *int64 `json:"cacheSize,omitempty" yaml:"cacheSize,omitempty"`
-	Endpoint  string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
-	Timeout   string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	CacheSize *int64    `json:"cachesize,omitempty" yaml:"cachesize,omitempty"`
+	Endpoint  string    `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Name      string    `json:"name,omitempty" yaml:"name,omitempty"`
+	Timeout   *Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_launch_template.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_launch_template.go
@@ -7,6 +7,6 @@ const (
 )
 
 type LaunchTemplate struct {
-	Name    string `json:"name,omitempty" yaml:"name,omitempty"`
-	Version *int64 `json:"version,omitempty" yaml:"version,omitempty"`
+	Name    *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Version *int64  `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_monitoring_input.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_monitoring_input.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	MonitoringInputType         = "monitoringInput"
-	MonitoringInputFieldAnswers = "answers"
-	MonitoringInputFieldVersion = "version"
+	MonitoringInputType                  = "monitoringInput"
+	MonitoringInputFieldAnswers          = "answers"
+	MonitoringInputFieldAnswersSetString = "answersSetString"
+	MonitoringInputFieldVersion          = "version"
 )
 
 type MonitoringInput struct {
-	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
+	Version          string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_monitoring_output.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_monitoring_output.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	MonitoringOutputType         = "monitoringOutput"
-	MonitoringOutputFieldAnswers = "answers"
-	MonitoringOutputFieldVersion = "version"
+	MonitoringOutputType                  = "monitoringOutput"
+	MonitoringOutputFieldAnswers          = "answers"
+	MonitoringOutputFieldAnswersSetString = "answersSetString"
+	MonitoringOutputFieldVersion          = "version"
 )
 
 type MonitoringOutput struct {
-	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
+	Version          string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_node.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_node.go
@@ -127,8 +127,6 @@ type NodeOperations interface {
 
 	ActionDrain(resource *Node, input *NodeDrainInput) error
 
-	ActionPleaseKillMe(resource *Node) error
-
 	ActionScaledown(resource *Node) error
 
 	ActionStopDrain(resource *Node) error
@@ -212,11 +210,6 @@ func (c *NodeClient) ActionCordon(resource *Node) error {
 
 func (c *NodeClient) ActionDrain(resource *Node, input *NodeDrainInput) error {
 	err := c.apiClient.Ops.DoAction(NodeType, "drain", &resource.Resource, input, nil)
-	return err
-}
-
-func (c *NodeClient) ActionPleaseKillMe(resource *Node) error {
-	err := c.apiClient.Ops.DoAction(NodeType, "pleaseKillMe", &resource.Resource, nil, nil)
 	return err
 }
 

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_node_group.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_node_group.go
@@ -23,22 +23,22 @@ const (
 )
 
 type NodeGroup struct {
-	DesiredSize          *int64            `json:"desiredSize,omitempty" yaml:"desiredSize,omitempty"`
-	DiskSize             *int64            `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	Ec2SshKey            string            `json:"ec2SshKey,omitempty" yaml:"ec2SshKey,omitempty"`
-	Gpu                  *bool             `json:"gpu,omitempty" yaml:"gpu,omitempty"`
-	ImageID              string            `json:"imageId,omitempty" yaml:"imageId,omitempty"`
-	InstanceType         string            `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
-	Labels               map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LaunchTemplate       *LaunchTemplate   `json:"launchTemplate,omitempty" yaml:"launchTemplate,omitempty"`
-	MaxSize              *int64            `json:"maxSize,omitempty" yaml:"maxSize,omitempty"`
-	MinSize              *int64            `json:"minSize,omitempty" yaml:"minSize,omitempty"`
-	NodegroupName        string            `json:"nodegroupName,omitempty" yaml:"nodegroupName,omitempty"`
-	RequestSpotInstances *bool             `json:"requestSpotInstances,omitempty" yaml:"requestSpotInstances,omitempty"`
-	ResourceTags         map[string]string `json:"resourceTags,omitempty" yaml:"resourceTags,omitempty"`
-	SpotInstanceTypes    []string          `json:"spotInstanceTypes,omitempty" yaml:"spotInstanceTypes,omitempty"`
-	Subnets              []string          `json:"subnets,omitempty" yaml:"subnets,omitempty"`
-	Tags                 map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
-	UserData             string            `json:"userData,omitempty" yaml:"userData,omitempty"`
-	Version              string            `json:"version,omitempty" yaml:"version,omitempty"`
+	DesiredSize          *int64             `json:"desiredSize,omitempty" yaml:"desiredSize,omitempty"`
+	DiskSize             *int64             `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	Ec2SshKey            *string            `json:"ec2SshKey,omitempty" yaml:"ec2SshKey,omitempty"`
+	Gpu                  *bool              `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+	ImageID              *string            `json:"imageId,omitempty" yaml:"imageId,omitempty"`
+	InstanceType         *string            `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
+	Labels               *map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LaunchTemplate       *LaunchTemplate    `json:"launchTemplate,omitempty" yaml:"launchTemplate,omitempty"`
+	MaxSize              *int64             `json:"maxSize,omitempty" yaml:"maxSize,omitempty"`
+	MinSize              *int64             `json:"minSize,omitempty" yaml:"minSize,omitempty"`
+	NodegroupName        *string            `json:"nodegroupName,omitempty" yaml:"nodegroupName,omitempty"`
+	RequestSpotInstances *bool              `json:"requestSpotInstances,omitempty" yaml:"requestSpotInstances,omitempty"`
+	ResourceTags         *map[string]string `json:"resourceTags,omitempty" yaml:"resourceTags,omitempty"`
+	SpotInstanceTypes    *[]string          `json:"spotInstanceTypes,omitempty" yaml:"spotInstanceTypes,omitempty"`
+	Subnets              *[]string          `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+	Tags                 *map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	UserData             *string            `json:"userData,omitempty" yaml:"userData,omitempty"`
+	Version              *string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_oidc_apply_input.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_oidc_apply_input.go
@@ -1,0 +1,14 @@
+package client
+
+const (
+	OIDCApplyInputType            = "oidcApplyInput"
+	OIDCApplyInputFieldCode       = "code"
+	OIDCApplyInputFieldEnabled    = "enabled"
+	OIDCApplyInputFieldOIDCConfig = "oidcConfig"
+)
+
+type OIDCApplyInput struct {
+	Code       string      `json:"code,omitempty" yaml:"code,omitempty"`
+	Enabled    bool        `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	OIDCConfig *OIDCConfig `json:"oidcConfig,omitempty" yaml:"oidcConfig,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_oidc_config.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_oidc_config.go
@@ -1,0 +1,50 @@
+package client
+
+const (
+	OIDCConfigType                     = "oidcConfig"
+	OIDCConfigFieldAccessMode          = "accessMode"
+	OIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
+	OIDCConfigFieldAnnotations         = "annotations"
+	OIDCConfigFieldAuthEndpoint        = "authEndpoint"
+	OIDCConfigFieldCertificate         = "certificate"
+	OIDCConfigFieldClientID            = "clientId"
+	OIDCConfigFieldClientSecret        = "clientSecret"
+	OIDCConfigFieldCreated             = "created"
+	OIDCConfigFieldCreatorID           = "creatorId"
+	OIDCConfigFieldEnabled             = "enabled"
+	OIDCConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
+	OIDCConfigFieldIssuer              = "issuer"
+	OIDCConfigFieldLabels              = "labels"
+	OIDCConfigFieldName                = "name"
+	OIDCConfigFieldOwnerReferences     = "ownerReferences"
+	OIDCConfigFieldPrivateKey          = "privateKey"
+	OIDCConfigFieldRancherURL          = "rancherUrl"
+	OIDCConfigFieldRemoved             = "removed"
+	OIDCConfigFieldScopes              = "scope"
+	OIDCConfigFieldType                = "type"
+	OIDCConfigFieldUUID                = "uuid"
+)
+
+type OIDCConfig struct {
+	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Certificate         string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret        string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
+	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
+	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PrivateKey          string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
+	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Scopes              string            `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_oidc_test_output.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_oidc_test_output.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	OIDCTestOutputType             = "oidcTestOutput"
+	OIDCTestOutputFieldRedirectURL = "redirectUrl"
+)
+
+type OIDCTestOutput struct {
+	RedirectURL string `json:"redirectUrl,omitempty" yaml:"redirectUrl,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_private_registry.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_private_registry.go
@@ -1,16 +1,18 @@
 package client
 
 const (
-	PrivateRegistryType           = "privateRegistry"
-	PrivateRegistryFieldIsDefault = "isDefault"
-	PrivateRegistryFieldPassword  = "password"
-	PrivateRegistryFieldURL       = "url"
-	PrivateRegistryFieldUser      = "user"
+	PrivateRegistryType                     = "privateRegistry"
+	PrivateRegistryFieldECRCredentialPlugin = "ecrCredentialPlugin"
+	PrivateRegistryFieldIsDefault           = "isDefault"
+	PrivateRegistryFieldPassword            = "password"
+	PrivateRegistryFieldURL                 = "url"
+	PrivateRegistryFieldUser                = "user"
 )
 
 type PrivateRegistry struct {
-	IsDefault bool   `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
-	Password  string `json:"password,omitempty" yaml:"password,omitempty"`
-	URL       string `json:"url,omitempty" yaml:"url,omitempty"`
-	User      string `json:"user,omitempty" yaml:"user,omitempty"`
+	ECRCredentialPlugin *ECRCredentialPlugin `json:"ecrCredentialPlugin,omitempty" yaml:"ecrCredentialPlugin,omitempty"`
+	IsDefault           bool                 `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
+	Password            string               `json:"password,omitempty" yaml:"password,omitempty"`
+	URL                 string               `json:"url,omitempty" yaml:"url,omitempty"`
+	User                string               `json:"user,omitempty" yaml:"user,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_provider_configuration.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_provider_configuration.go
@@ -1,0 +1,18 @@
+package client
+
+const (
+	ProviderConfigurationType           = "providerConfiguration"
+	ProviderConfigurationFieldAESCBC    = "aescbc"
+	ProviderConfigurationFieldAESGCM    = "aesgcm"
+	ProviderConfigurationFieldIdentity  = "identity"
+	ProviderConfigurationFieldKMS       = "kms"
+	ProviderConfigurationFieldSecretbox = "secretbox"
+)
+
+type ProviderConfiguration struct {
+	AESCBC    *AESConfiguration       `json:"aescbc,omitempty" yaml:"aescbc,omitempty"`
+	AESGCM    *AESConfiguration       `json:"aesgcm,omitempty" yaml:"aesgcm,omitempty"`
+	Identity  *IdentityConfiguration  `json:"identity,omitempty" yaml:"identity,omitempty"`
+	KMS       *KMSConfiguration       `json:"kms,omitempty" yaml:"kms,omitempty"`
+	Secretbox *SecretboxConfiguration `json:"secretbox,omitempty" yaml:"secretbox,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_rancher_kubernetes_engine_config.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_rancher_kubernetes_engine_config.go
@@ -11,6 +11,7 @@ const (
 	RancherKubernetesEngineConfigFieldCloudProvider       = "cloudProvider"
 	RancherKubernetesEngineConfigFieldClusterName         = "clusterName"
 	RancherKubernetesEngineConfigFieldDNS                 = "dns"
+	RancherKubernetesEngineConfigFieldEnableCRIDockerd    = "enableCriDockerd"
 	RancherKubernetesEngineConfigFieldIgnoreDockerVersion = "ignoreDockerVersion"
 	RancherKubernetesEngineConfigFieldIngress             = "ingress"
 	RancherKubernetesEngineConfigFieldMonitoring          = "monitoring"
@@ -40,6 +41,7 @@ type RancherKubernetesEngineConfig struct {
 	CloudProvider       *CloudProvider       `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
 	ClusterName         string               `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 	DNS                 *DNSConfig           `json:"dns,omitempty" yaml:"dns,omitempty"`
+	EnableCRIDockerd    *bool                `json:"enableCriDockerd,omitempty" yaml:"enableCriDockerd,omitempty"`
 	IgnoreDockerVersion *bool                `json:"ignoreDockerVersion,omitempty" yaml:"ignoreDockerVersion,omitempty"`
 	Ingress             *IngressConfig       `json:"ingress,omitempty" yaml:"ingress,omitempty"`
 	Monitoring          *MonitoringConfig    `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_resource_configuration.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_resource_configuration.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	ResourceConfigurationType           = "resourceConfiguration"
+	ResourceConfigurationFieldProviders = "providers"
+	ResourceConfigurationFieldResources = "resources"
+)
+
+type ResourceConfiguration struct {
+	Providers []ProviderConfiguration `json:"providers,omitempty" yaml:"providers,omitempty"`
+	Resources []string                `json:"resources,omitempty" yaml:"resources,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_rke_system_images.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_rke_system_images.go
@@ -30,6 +30,7 @@ const (
 	RKESystemImagesFieldFlannelCNI                = "flannelCni"
 	RKESystemImagesFieldIngress                   = "ingress"
 	RKESystemImagesFieldIngressBackend            = "ingressBackend"
+	RKESystemImagesFieldIngressWebhook            = "ingressWebhook"
 	RKESystemImagesFieldKubeDNS                   = "kubedns"
 	RKESystemImagesFieldKubeDNSAutoscaler         = "kubednsAutoscaler"
 	RKESystemImagesFieldKubeDNSSidecar            = "kubednsSidecar"
@@ -73,6 +74,7 @@ type RKESystemImages struct {
 	FlannelCNI                string `json:"flannelCni,omitempty" yaml:"flannelCni,omitempty"`
 	Ingress                   string `json:"ingress,omitempty" yaml:"ingress,omitempty"`
 	IngressBackend            string `json:"ingressBackend,omitempty" yaml:"ingressBackend,omitempty"`
+	IngressWebhook            string `json:"ingressWebhook,omitempty" yaml:"ingressWebhook,omitempty"`
 	KubeDNS                   string `json:"kubedns,omitempty" yaml:"kubedns,omitempty"`
 	KubeDNSAutoscaler         string `json:"kubednsAutoscaler,omitempty" yaml:"kubednsAutoscaler,omitempty"`
 	KubeDNSSidecar            string `json:"kubednsSidecar,omitempty" yaml:"kubednsSidecar,omitempty"`

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_rolling_update_daemon_set.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_rolling_update_daemon_set.go
@@ -6,9 +6,11 @@ import (
 
 const (
 	RollingUpdateDaemonSetType                = "rollingUpdateDaemonSet"
+	RollingUpdateDaemonSetFieldMaxSurge       = "maxSurge"
 	RollingUpdateDaemonSetFieldMaxUnavailable = "maxUnavailable"
 )
 
 type RollingUpdateDaemonSet struct {
+	MaxSurge       intstr.IntOrString `json:"maxSurge,omitempty" yaml:"maxSurge,omitempty"`
 	MaxUnavailable intstr.IntOrString `json:"maxUnavailable,omitempty" yaml:"maxUnavailable,omitempty"`
 }

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_s3credential_config.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_s3credential_config.go
@@ -1,0 +1,24 @@
+package client
+
+const (
+	S3CredentialConfigType                      = "s3CredentialConfig"
+	S3CredentialConfigFieldAccessKey            = "accessKey"
+	S3CredentialConfigFieldDefaultBucket        = "defaultBucket"
+	S3CredentialConfigFieldDefaultEndpoint      = "defaultEndpoint"
+	S3CredentialConfigFieldDefaultEndpointCA    = "defaultEndpointCA"
+	S3CredentialConfigFieldDefaultFolder        = "defaultFolder"
+	S3CredentialConfigFieldDefaultRegion        = "defaultRegion"
+	S3CredentialConfigFieldDefaultSkipSSLVerify = "defaultSkipSSLVerify"
+	S3CredentialConfigFieldSecretKey            = "secretKey"
+)
+
+type S3CredentialConfig struct {
+	AccessKey            string `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
+	DefaultBucket        string `json:"defaultBucket,omitempty" yaml:"defaultBucket,omitempty"`
+	DefaultEndpoint      string `json:"defaultEndpoint,omitempty" yaml:"defaultEndpoint,omitempty"`
+	DefaultEndpointCA    string `json:"defaultEndpointCA,omitempty" yaml:"defaultEndpointCA,omitempty"`
+	DefaultFolder        string `json:"defaultFolder,omitempty" yaml:"defaultFolder,omitempty"`
+	DefaultRegion        string `json:"defaultRegion,omitempty" yaml:"defaultRegion,omitempty"`
+	DefaultSkipSSLVerify string `json:"defaultSkipSSLVerify,omitempty" yaml:"defaultSkipSSLVerify,omitempty"`
+	SecretKey            string `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_secretbox_configuration.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_secretbox_configuration.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	SecretboxConfigurationType      = "secretboxConfiguration"
+	SecretboxConfigurationFieldKeys = "keys"
+)
+
+type SecretboxConfiguration struct {
+	Keys []Key `json:"keys,omitempty" yaml:"keys,omitempty"`
+}

--- a/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_secrets_encryption_config.go
+++ b/cluster-autoscaler/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_secrets_encryption_config.go
@@ -7,6 +7,6 @@ const (
 )
 
 type SecretsEncryptionConfig struct {
-	CustomConfig map[string]interface{} `json:"customConfig,omitempty" yaml:"customConfig,omitempty"`
-	Enabled      bool                   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	CustomConfig *EncryptionConfiguration `json:"customConfig,omitempty" yaml:"customConfig,omitempty"`
+	Enabled      bool                     `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }

--- a/cluster-autoscaler/vendor/modules.txt
+++ b/cluster-autoscaler/vendor/modules.txt
@@ -490,7 +490,7 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/quobyte/api v0.1.8 => github.com/quobyte/api v0.1.8
 github.com/quobyte/api
-# github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b => github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b
+# github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133 => github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
 ## explicit
 github.com/rancher/norman/clientbase
 github.com/rancher/norman/httperror
@@ -499,7 +499,7 @@ github.com/rancher/norman/types/convert
 github.com/rancher/norman/types/definition
 github.com/rancher/norman/types/slice
 github.com/rancher/norman/types/values
-# github.com/rancher/rancher/pkg/client v0.0.0-20210826004905-903c574c8351 => github.com/PlayKids/rancher/pkg/client v0.0.0-20210826004905-903c574c8351
+# github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c => github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c
 ## explicit
 github.com/rancher/rancher/pkg/client/generated/management/v3
 # github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106
@@ -851,7 +851,7 @@ k8s.io/api/scheduling/v1beta1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apimachinery v0.18.8 => /tmp/ca-update-vendor.NGE2/kubernetes/staging/src/k8s.io/apimachinery
+# k8s.io/apimachinery v0.21.0 => /tmp/ca-update-vendor.NGE2/kubernetes/staging/src/k8s.io/apimachinery
 ## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -2112,6 +2112,6 @@ sigs.k8s.io/yaml
 # sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
 # github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
 # github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
-# github.com/rancher/norman => github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b
-# github.com/rancher/rancher/pkg/client => github.com/PlayKids/rancher/pkg/client v0.0.0-20210826004905-903c574c8351
+# github.com/rancher/norman => github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
+# github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20210830223634-df2432ad895c
 # k8s.io/kubernetes => /tmp/ca-update-vendor.NGE2/kubernetes

--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.20.0-PLAYKIDS-1"
+const ClusterAutoscalerVersion = "1.20.0-PLAYKIDS-2"


### PR DESCRIPTION
Now that Rancher has a proper scale down API we can finally retire its fork and switch over to the official releases.
We still need to maintain this fork... at least for now. Let's keep an eye out for kubernetes/autoscaler#4041 😉 

![image](https://user-images.githubusercontent.com/10561431/136437403-d87d32ac-76c4-486e-867c-d57e0dfe0b22.png)
